### PR TITLE
Вынесли Tracker в отдельный микросервис

### DIFF
--- a/Dodo.Core/Dodo.Core.csproj
+++ b/Dodo.Core/Dodo.Core.csproj
@@ -9,4 +9,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Dodo.Tracker\Dodo.Tracker.Contracts\Dodo.Tracker.Contracts.csproj" />
+  </ItemGroup>
 </Project>

--- a/Dodo.Core/Services/ITrackerClient.cs
+++ b/Dodo.Core/Services/ITrackerClient.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading.Tasks;
+using Dodo.Core.Common;
+using Dodo.Tracker.Contracts;
+using Dodo.Tracker.Contracts.Enums;
+
+namespace Dodo.Core.Services
+{
+    public interface ITrackerClient
+    {
+        Task<ProductionOrder[]> GetOrdersByTypeAsync(Uuid unitUuid, OrderType type, int limit);
+    }
+}

--- a/Dodo.RestaurantBoard.sln
+++ b/Dodo.RestaurantBoard.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dodo.RestaurantBoard.Domain
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dodo.RestaurantBoard.Site", "src\Dodo.RestaurantBoard\Dodo.RestaurantBoard.Site\Dodo.RestaurantBoard.Site.csproj", "{C73097A9-078D-41A9-85FA-71F7BF0571C5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dodo.Tracker.WebApi", "Dodo.Tracker.WebApi\Dodo.Tracker.WebApi.csproj", "{393846DC-A94D-41E7-84BC-31FBB0A2F958}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{C73097A9-078D-41A9-85FA-71F7BF0571C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C73097A9-078D-41A9-85FA-71F7BF0571C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C73097A9-078D-41A9-85FA-71F7BF0571C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{393846DC-A94D-41E7-84BC-31FBB0A2F958}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{393846DC-A94D-41E7-84BC-31FBB0A2F958}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{393846DC-A94D-41E7-84BC-31FBB0A2F958}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{393846DC-A94D-41E7-84BC-31FBB0A2F958}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Dodo.Tracker.WebApi/Controllers/OrdersController.cs
+++ b/Dodo.Tracker.WebApi/Controllers/OrdersController.cs
@@ -11,11 +11,10 @@ namespace Dodo.Tracker.WebApi.Controllers
     [ApiController]
     public class OrdersController : ControllerBase
     {
-        [HttpGet("{unitUuid}/{type}")]
+        [HttpGet("unit/{unitUuid}")]
         public ActionResult<IEnumerable<ProductionOrder>> GetOrdersByType(
             [FromRoute] string unitUuid,
-            [FromRoute] OrderType type,
-            [FromQuery] OrderState[] states,
+            [FromQuery] OrderType type,
             [FromQuery] int limit)
         {
             var orders = new[]

--- a/Dodo.Tracker.WebApi/Controllers/OrdersController.cs
+++ b/Dodo.Tracker.WebApi/Controllers/OrdersController.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using Dodo.Tracker.Contracts;
+using Dodo.Tracker.Contracts.Enums;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+
+namespace Dodo.Tracker.WebApi.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class OrdersController : ControllerBase
+    {
+        [HttpGet("{unitUuid}/{type}")]
+        public ActionResult<IEnumerable<ProductionOrder>> GetOrdersByType(
+            [FromRoute] string unitUuid,
+            [FromRoute] OrderType type,
+            [FromQuery] OrderState[] states,
+            [FromQuery] int limit)
+        {
+            var orders = new[]
+            {
+                new ProductionOrder
+                {
+                    Id = 55,
+                    Number = 3,
+                    ClientName = "Пупа",
+                    ChangeDate = DateTime.Now.AddMinutes(-5),
+                },
+                new ProductionOrder
+                {
+                    Id = 56,
+                    Number = 4,
+                    ClientName = "Лупа",
+                    ChangeDate = DateTime.Now.AddMinutes(-3),
+                },
+            };
+
+            return orders;
+        }
+    }
+}

--- a/Dodo.Tracker.WebApi/Dodo.Tracker.WebApi.csproj
+++ b/Dodo.Tracker.WebApi/Dodo.Tracker.WebApi.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>11.0.2</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Dodo.Tracker\Dodo.Tracker.Contracts\Dodo.Tracker.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/Dodo.Tracker.WebApi/Program.cs
+++ b/Dodo.Tracker.WebApi/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Dodo.Tracker.WebApi
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/Dodo.Tracker.WebApi/Properties/launchSettings.json
+++ b/Dodo.Tracker.WebApi/Properties/launchSettings.json
@@ -12,7 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "api/values",
+      "launchUrl": "api/orders",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -20,8 +20,8 @@
     "Dodo.Tracker.WebApi": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/values",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "launchUrl": "api/orders",
+      "applicationUrl": "http://localhost:5050",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Dodo.Tracker.WebApi/Properties/launchSettings.json
+++ b/Dodo.Tracker.WebApi/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false, 
+    "anonymousAuthentication": true, 
+    "iisExpress": {
+      "applicationUrl": "http://localhost:5375",
+      "sslPort": 44306
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "api/values",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Dodo.Tracker.WebApi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "api/values",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Dodo.Tracker.WebApi/Startup.cs
+++ b/Dodo.Tracker.WebApi/Startup.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Dodo.Tracker.WebApi
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
+            app.UseMvc();
+        }
+    }
+}

--- a/Dodo.Tracker.WebApi/Startup.cs
+++ b/Dodo.Tracker.WebApi/Startup.cs
@@ -35,12 +35,6 @@ namespace Dodo.Tracker.WebApi
             {
                 app.UseDeveloperExceptionPage();
             }
-            else
-            {
-                app.UseHsts();
-            }
-
-            app.UseHttpsRedirection();
             app.UseMvc();
         }
     }

--- a/Dodo.Tracker.WebApi/appsettings.Development.json
+++ b/Dodo.Tracker.WebApi/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/Dodo.Tracker.WebApi/appsettings.json
+++ b/Dodo.Tracker.WebApi/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Domain/Services/TrackerClient.cs
+++ b/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Domain/Services/TrackerClient.cs
@@ -1,35 +1,35 @@
-﻿using Dodo.Core.Common;
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Dodo.Core.Common;
+using Dodo.Core.Services;
 using Dodo.Tracker.Contracts;
 using Dodo.Tracker.Contracts.Enums;
+using Newtonsoft.Json;
 
 namespace Dodo.RestaurantBoard.Domain.Services
 {
-	public interface ITrackerClient
-	{
-		ProductionOrder[] GetOrdersByType(Uuid unitUuid, OrderType type, OrderState[] states, int limit);
-	}
-
 	public class TrackerClient : ITrackerClient
 	{
-		public ProductionOrder[] GetOrdersByType(Uuid unitUuid, OrderType type, OrderState[] states, int limit)
-		{
-			var orders = new[]
-			{
-				new ProductionOrder
-				{
-					Id = 55,
-					Number = 3,
-					ClientName = "Пупа"
-				},
-				new ProductionOrder
-				{
-					Id = 56,
-					Number = 4,
-					ClientName = "Лупа"
-				},
-			};
+		private readonly HttpClient _client;
 
-			return orders;
+		public TrackerClient(Uri baseUri)
+		{
+			_client = new HttpClient
+			{
+				BaseAddress = baseUri
+			};
+		}
+
+		public async Task<ProductionOrder[]> GetOrdersByTypeAsync(
+			Uuid unitUuid,
+			OrderType type,
+			int limit)
+		{
+			var url = $"api/orders/unit/{unitUuid}?type={type}&limit={limit}";
+			var json = await _client.GetStringAsync(url);
+
+			return JsonConvert.DeserializeObject<ProductionOrder[]>(json);
 		}
 	}
 }

--- a/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Site/App_Start/AutofacConfig.cs
+++ b/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Site/App_Start/AutofacConfig.cs
@@ -1,18 +1,20 @@
-﻿using Autofac;
+﻿using System;
+using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using Dodo.Core.Services;
 using Dodo.RestaurantBoard.Domain.Services;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Dodo.RestaurantBoard.Site
 {
 	public static class AutofacConfig
 	{
-		public static IContainer Register(IServiceCollection services)
+		public static IContainer Register(IServiceCollection services, IConfiguration configuration)
 		{
 			var builder = new ContainerBuilder()
-				.RegisterServices();
+				.RegisterServices(configuration);
 
 			services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 			builder.Populate(services);
@@ -20,13 +22,15 @@ namespace Dodo.RestaurantBoard.Site
 			return builder.Build();
 		}
 
-		private static ContainerBuilder RegisterServices(this ContainerBuilder builder)
+		private static ContainerBuilder RegisterServices(this ContainerBuilder builder, IConfiguration configuration)
 		{
 			builder.RegisterType<DepartmentsStructureService>().As<IDepartmentsStructureService>().SingleInstance();
 			builder.RegisterType<ManagementService>().As<IManagementService>().SingleInstance();
 			builder.RegisterType<ClientService>().As<IClientsService>().SingleInstance();
-
-			builder.RegisterType<TrackerClient>().As<ITrackerClient>();
+			builder.RegisterType<TrackerClient>()
+				.As<ITrackerClient>()
+				.WithParameter("baseUri", new Uri(configuration["Tracker:Uri"], UriKind.Absolute))
+				.SingleInstance();
 
 			return builder;
 		}

--- a/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Site/Controllers/BoardsController.cs
+++ b/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Site/Controllers/BoardsController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Dodo.Core.Common;
 using Dodo.Core.DomainModel.Clients;
 using Dodo.Core.DomainModel.Departments.Departments;
@@ -86,17 +87,16 @@ namespace Dodo.RestaurantBoard.Site.Controllers
         }
 
         [Microsoft.AspNetCore.Mvc.HttpGet]
-        public JsonResult GetOrderReadinessToStationary(int unitId)
+        public async Task<JsonResult> GetOrderReadinessToStationary(int unitId)
         {
             const int maxCountOrders = 16;
 
             var pizzeria = _departmentsStructureService.GetPizzeriaOrCache(unitId);
 
-            var orders = _trackerClient
-                .GetOrdersByType(pizzeria.Uuid, OrderType.Stationary, new[] { OrderState.OnTheShelf }, maxCountOrders)
+            var orders = (await _trackerClient
+                .GetOrdersByTypeAsync(pizzeria.Uuid, OrderType.Stationary, maxCountOrders))
                 .Select(MapToRestaurantReadnessOrders)
                 .ToArray();
-
 
             var clientTreatment = pizzeria.ClientTreatment;
             ClientIcon[] icons = { };

--- a/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Site/Properties/launchSettings.json
+++ b/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Site/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     "Dodo.RestaurantBoard.Site.Core": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Site/Startup.cs
+++ b/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Site/Startup.cs
@@ -72,7 +72,7 @@ namespace Dodo.RestaurantBoard.Site.Core
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
-            var container = AutofacConfig.Register(services);
+            var container = AutofacConfig.Register(services, Configuration);
             ApplicationContainer = container;
             return new AutofacServiceProvider(ApplicationContainer);
         }
@@ -90,10 +90,8 @@ namespace Dodo.RestaurantBoard.Site.Core
             else
             {
                 app.UseExceptionHandler("/Home/Error");
-                app.UseHsts();
             }
 
-            app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseCookiePolicy();
             app.UseSession();

--- a/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Site/appsettings.json
+++ b/src/Dodo.RestaurantBoard/Dodo.RestaurantBoard.Site/appsettings.json
@@ -4,5 +4,8 @@
       "Default": "Warning"
     }
   },
+  "Tracker": {
+    "Uri": "http://localhost:5050"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
- Создали проект  Dodo.Tracker.WebApi, в который перенесли логику класса TrackerClient
- Поменяли существующий класс TrackerClient, теперь он не отдает данные напрямую, а использует HttpClient, чтобы ходить за данными в новый сервис
- Убрали везде https и перевели оба сервиса на http. 
P.S. Если вдруг при запуске проекта у вас браузер по прежнему открывается на https://localhost:5001, то нужно перейти в раздел "Run/Debug Configurations -> вкладка Browser / Live Edit" - там поправить строку на http://localhost:5000